### PR TITLE
MULE-12609: Every exported Mule package must contain api

### DIFF
--- a/src/test/java/org/mule/extension/file/FileWriteTypeTestCase.java
+++ b/src/test/java/org/mule/extension/file/FileWriteTypeTestCase.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertThat;
 
 import org.mule.extension.file.common.api.FileWriteMode;
 import org.mule.runtime.core.api.Event;
-import org.mule.runtime.core.message.OutputHandler;
+import org.mule.runtime.core.api.message.OutputHandler;
 import org.mule.test.runner.RunnerDelegateTo;
 
 import java.io.ByteArrayInputStream;


### PR DESCRIPTION
_ Moving more classes from org.mule.runtime.core.message to api/internal