### PR TITLE
MULE-12947: file:move error messages say 'Can't copy ... ' instead of…

### DIFF
--- a/src/main/java/org/mule/extension/file/internal/command/AbstractLocalCopyCommand.java
+++ b/src/main/java/org/mule/extension/file/internal/command/AbstractLocalCopyCommand.java
@@ -102,8 +102,7 @@ abstract class AbstractLocalCopyCommand extends LocalFileCommand {
         targetPath = targetPath.resolve(targetFileName);
       } else {
         throw new IllegalPathException(format("Can't %s '%s' to '%s' because the destination path " + "doesn't exists",
-                                              getAction(),
-                                              source.toAbsolutePath(), targetPath.toAbsolutePath()));
+                                              getAction(), source.toAbsolutePath(), targetPath.toAbsolutePath()));
       }
     }
     return targetPath;

--- a/src/main/java/org/mule/extension/file/internal/command/LocalCopyCommand.java
+++ b/src/main/java/org/mule/extension/file/internal/command/LocalCopyCommand.java
@@ -6,7 +6,6 @@
  */
 package org.mule.extension.file.internal.command;
 
-import static org.apache.commons.io.FileUtils.copyDirectory;
 import org.mule.extension.file.common.api.FileConnectorConfig;
 import org.mule.extension.file.common.api.command.CopyCommand;
 import org.mule.extension.file.internal.LocalFileSystem;
@@ -14,6 +13,8 @@ import org.mule.extension.file.internal.LocalFileSystem;
 import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import static org.apache.commons.io.FileUtils.copyDirectory;
 
 /**
  * A {@link AbstractLocalCopyCommand} which implements the {@link CopyCommand} contract
@@ -60,6 +61,6 @@ public final class LocalCopyCommand extends AbstractLocalCopyCommand implements 
    */
   @Override
   protected String getAction() {
-    return "copying";
+    return "copy";
   }
 }

--- a/src/main/java/org/mule/extension/file/internal/command/LocalMoveCommand.java
+++ b/src/main/java/org/mule/extension/file/internal/command/LocalMoveCommand.java
@@ -6,15 +6,16 @@
  */
 package org.mule.extension.file.internal.command;
 
-import static org.apache.commons.io.FileUtils.moveDirectory;
-import org.mule.extension.file.internal.LocalFileSystem;
-import org.mule.runtime.core.api.util.FileUtils;
 import org.mule.extension.file.common.api.FileConnectorConfig;
 import org.mule.extension.file.common.api.command.MoveCommand;
+import org.mule.extension.file.internal.LocalFileSystem;
+import org.mule.runtime.core.api.util.FileUtils;
 
 import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import static org.apache.commons.io.FileUtils.moveDirectory;
 
 /**
  * A {@link AbstractLocalCopyCommand} which implements the {@link MoveCommand} contract
@@ -68,6 +69,6 @@ public final class LocalMoveCommand extends AbstractLocalCopyCommand implements 
    */
   @Override
   protected String getAction() {
-    return "moving";
+    return "move";
   }
 }

--- a/src/test/java/org/mule/extension/file/FileCopyTestCase.java
+++ b/src/test/java/org/mule/extension/file/FileCopyTestCase.java
@@ -6,6 +6,14 @@
  */
 package org.mule.extension.file;
 
+import io.qameta.allure.Feature;
+import org.junit.Test;
+import org.mule.extension.file.common.api.exceptions.FileAlreadyExistsException;
+import org.mule.extension.file.common.api.exceptions.IllegalPathException;
+
+import java.io.File;
+import java.io.IOException;
+
 import static java.lang.String.format;
 import static org.apache.commons.io.FileUtils.write;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -13,14 +21,6 @@ import static org.junit.Assert.assertThat;
 import static org.mule.extension.file.AllureConstants.FileFeature.FILE_EXTENSION;
 import static org.mule.extension.file.common.api.exceptions.FileError.FILE_ALREADY_EXISTS;
 import static org.mule.extension.file.common.api.exceptions.FileError.ILLEGAL_PATH;
-import org.mule.extension.file.common.api.exceptions.FileAlreadyExistsException;
-import org.mule.extension.file.common.api.exceptions.IllegalPathException;
-
-import java.io.File;
-import java.io.IOException;
-
-import org.junit.Test;
-import io.qameta.allure.Feature;
 
 @Feature(FILE_EXTENSION)
 public class FileCopyTestCase extends FileConnectorTestCase {


### PR DESCRIPTION
… 'Can't move ...'