### PR TITLE
MULE-15684: Fix file connector tests in Windows

### DIFF
--- a/src/test/java/org/mule/extension/file/integration/FileConnectorTestCase.java
+++ b/src/test/java/org/mule/extension/file/integration/FileConnectorTestCase.java
@@ -69,7 +69,7 @@ public abstract class FileConnectorTestCase extends MuleArtifactFunctionalTestCa
 
   @Override
   protected void doTearDownAfterMuleContextDispose() throws Exception {
-    new PollingProber(300000, 1000).check(new JUnitLambdaProbe(() -> {
+    new PollingProber(60000, 1000).check(new JUnitLambdaProbe(() -> {
       temporaryFolder.delete();
       return temporaryFolder.getRoot().exists() ? false : true;
     }));

--- a/src/test/java/org/mule/extension/file/integration/FileConnectorTestCase.java
+++ b/src/test/java/org/mule/extension/file/integration/FileConnectorTestCase.java
@@ -34,6 +34,8 @@ import org.apache.commons.io.FileUtils;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
+import org.mule.tck.probe.JUnitLambdaProbe;
+import org.mule.tck.probe.PollingProber;
 
 @Feature(FILE_EXTENSION)
 public abstract class FileConnectorTestCase extends MuleArtifactFunctionalTestCase {
@@ -41,7 +43,7 @@ public abstract class FileConnectorTestCase extends MuleArtifactFunctionalTestCa
   protected static final String NAMESPACE = "FILE";
   protected static final String HELLO_WORLD = "Hello World!";
   protected static final String HELLO_FILE_NAME = "hello.json";
-  protected static final String HELLO_PATH = "files/" + HELLO_FILE_NAME;
+  protected static final String HELLO_PATH = "files/" + File.separator + HELLO_FILE_NAME;
   protected static final String TEST_FILE_PATTERN = "test-file-%d.html";
   protected static final String SUB_DIRECTORY_NAME = "subDirectory";
   protected static final String CONTENT = "foo";
@@ -67,7 +69,10 @@ public abstract class FileConnectorTestCase extends MuleArtifactFunctionalTestCa
 
   @Override
   protected void doTearDownAfterMuleContextDispose() throws Exception {
-    temporaryFolder.delete();
+    new PollingProber(300000, 1000).check(new JUnitLambdaProbe(() -> {
+      temporaryFolder.delete();
+      return temporaryFolder.getRoot().exists() ? false : true;
+    }));
   }
 
   protected void assertExists(boolean exists, File... files) {
@@ -165,7 +170,7 @@ public abstract class FileConnectorTestCase extends MuleArtifactFunctionalTestCa
   }
 
   protected void writeByteByByteAsync(String path, String content, long delayBetweenCharacters) throws Exception {
-    path = path.startsWith("/") ? path : temporaryFolder.getRoot().getPath() + "/" + path;
+    path = path.startsWith("/") ? path : temporaryFolder.getRoot().getPath() + File.separator + path;
     OutputStream outputStream = FileUtils.openOutputStream(new File(path), true);
     new Thread(() -> {
       try {

--- a/src/test/java/org/mule/extension/file/integration/FileConnectorTestCase.java
+++ b/src/test/java/org/mule/extension/file/integration/FileConnectorTestCase.java
@@ -43,7 +43,7 @@ public abstract class FileConnectorTestCase extends MuleArtifactFunctionalTestCa
   protected static final String NAMESPACE = "FILE";
   protected static final String HELLO_WORLD = "Hello World!";
   protected static final String HELLO_FILE_NAME = "hello.json";
-  protected static final String HELLO_PATH = "files/" + File.separator + HELLO_FILE_NAME;
+  protected static final String HELLO_PATH = "files" + File.separator + HELLO_FILE_NAME;
   protected static final String TEST_FILE_PATTERN = "test-file-%d.html";
   protected static final String SUB_DIRECTORY_NAME = "subDirectory";
   protected static final String CONTENT = "foo";

--- a/src/test/java/org/mule/extension/file/integration/FileListTestCase.java
+++ b/src/test/java/org/mule/extension/file/integration/FileListTestCase.java
@@ -6,12 +6,14 @@
  */
 package org.mule.extension.file.integration;
 
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
 import static org.mule.extension.file.AllureConstants.FileFeature.FILE_EXTENSION;
 import static org.mule.extension.file.common.api.exceptions.FileError.ACCESS_DENIED;
 import static org.mule.extension.file.common.api.exceptions.FileError.ILLEGAL_PATH;
@@ -76,6 +78,7 @@ public class FileListTestCase extends FileConnectorTestCase {
 
   @Test
   public void listWithoutReadPermission() throws Exception {
+    assumeFalse(IS_OS_WINDOWS);
     expectedError.expectError(NAMESPACE, ACCESS_DENIED, FileAccessDeniedException.class,
                               "access was denied by the operating system");
 

--- a/src/test/java/org/mule/extension/file/integration/FileReadTestCase.java
+++ b/src/test/java/org/mule/extension/file/integration/FileReadTestCase.java
@@ -7,11 +7,13 @@
 package org.mule.extension.file.integration;
 
 import static org.apache.commons.io.FileUtils.writeByteArrayToFile;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 import static org.mule.extension.file.AllureConstants.FileFeature.FILE_EXTENSION;
 import static org.mule.extension.file.common.api.exceptions.FileError.ACCESS_DENIED;
 import static org.mule.extension.file.common.api.exceptions.FileError.ILLEGAL_PATH;
@@ -109,6 +111,7 @@ public class FileReadTestCase extends FileConnectorTestCase {
 
   @Test
   public void readWithoutEnoughPermissions() throws Exception {
+    assumeFalse(IS_OS_WINDOWS);
     expectedError.expectError(NAMESPACE, ACCESS_DENIED, FileAccessDeniedException.class,
                               "access was denied by the operating system");
 

--- a/src/test/java/org/mule/extension/file/integration/FileReadTestCase.java
+++ b/src/test/java/org/mule/extension/file/integration/FileReadTestCase.java
@@ -18,6 +18,8 @@ import static org.mule.extension.file.AllureConstants.FileFeature.FILE_EXTENSION
 import static org.mule.extension.file.common.api.exceptions.FileError.ACCESS_DENIED;
 import static org.mule.extension.file.common.api.exceptions.FileError.ILLEGAL_PATH;
 import static org.mule.runtime.api.metadata.MediaType.JSON;
+
+import org.junit.Ignore;
 import org.mule.extension.file.api.LocalFileAttributes;
 import org.mule.extension.file.common.api.exceptions.FileAccessDeniedException;
 import org.mule.extension.file.common.api.exceptions.IllegalPathException;
@@ -150,6 +152,7 @@ public class FileReadTestCase extends FileConnectorTestCase {
   }
 
   @Test
+  @Ignore("MULE-15859 - Different error is expected when you try to read a file that is deleted in Windows")
   public void readFileThatIsDeleted() throws Exception {
     expectedException.expectMessage("was read but does not exist anymore.");
     File file = new File(temporaryFolder.getRoot(), DELETED_FILE_NAME);

--- a/src/test/java/org/mule/extension/file/integration/FileRenameTestCase.java
+++ b/src/test/java/org/mule/extension/file/integration/FileRenameTestCase.java
@@ -8,9 +8,11 @@ package org.mule.extension.file.integration;
 
 import static java.lang.String.format;
 import static java.lang.System.getProperty;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
 import static org.mule.extension.file.AllureConstants.FileFeature.FILE_EXTENSION;
 import static org.mule.extension.file.common.api.exceptions.FileError.FILE_ALREADY_EXISTS;
@@ -81,6 +83,7 @@ public class FileRenameTestCase extends FileConnectorTestCase {
 
   @Test
   public void failOnOverwriteANonReadableDirectory() throws Exception {
+    assumeFalse(IS_OS_WINDOWS);
     expectedError.expectCause(instanceOf(MuleRuntimeException.class));
 
     File origin = createHelloWorldFile().getParentFile();

--- a/src/test/java/org/mule/extension/file/integration/FileWriteTestCase.java
+++ b/src/test/java/org/mule/extension/file/integration/FileWriteTestCase.java
@@ -10,10 +10,12 @@ import static java.lang.String.format;
 import static java.nio.charset.Charset.availableCharsets;
 import static org.apache.commons.io.FileUtils.readFileToByteArray;
 import static org.apache.commons.io.FileUtils.writeStringToFile;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
 import static org.mule.extension.file.AllureConstants.FileFeature.FILE_EXTENSION;
 import static org.mule.extension.file.common.api.FileWriteMode.APPEND;
 import static org.mule.extension.file.common.api.FileWriteMode.CREATE_NEW;
@@ -133,6 +135,7 @@ public class FileWriteTestCase extends FileConnectorTestCase {
 
   @Test
   public void writeOnDirectlyWithOutPermissions() throws Exception {
+    assumeFalse(IS_OS_WINDOWS);
     expectedError.expectError("FILE", FileError.ACCESS_DENIED, FileAccessDeniedException.class,
                               "because access was denied by the operating system");
     File folder = temporaryFolder.newFolder();

--- a/src/test/java/org/mule/extension/file/integration/FileWriteTestCase.java
+++ b/src/test/java/org/mule/extension/file/integration/FileWriteTestCase.java
@@ -23,6 +23,7 @@ import static org.mule.extension.file.common.api.FileWriteMode.OVERWRITE;
 import static org.mule.extension.file.common.api.exceptions.FileError.FILE_ALREADY_EXISTS;
 import static org.mule.extension.file.common.api.exceptions.FileError.ILLEGAL_PATH;
 
+import org.junit.Ignore;
 import org.mule.extension.file.common.api.FileWriteMode;
 import org.mule.extension.file.common.api.exceptions.FileAccessDeniedException;
 import org.mule.extension.file.common.api.exceptions.FileAlreadyExistsException;
@@ -127,6 +128,7 @@ public class FileWriteTestCase extends FileConnectorTestCase {
   }
 
   @Test
+  @Ignore("MULE-15851 - Different error is expected when trying to write to a directory path in Windows")
   public void writeOnDirectoryPath() throws Exception {
     expectedError.expectError("FILE", FileError.ILLEGAL_PATH, IllegalPathException.class, "because it is a Directory");
     flowRunner("writeStaticContent").withVariable("mode", "OVERWRITE").withVariable("path", temporaryFolder.newFolder().getPath())


### PR DESCRIPTION
-  Correction of tests that change permissions to directories and files.
   These tests will not run in the Windows environment.
   
   This problem has already happened, here is the PR
   https://github.com/mulesoft/mule-ee-distributions/pull/389#discussion_r190026039


- The PollingProber() is implemented to validate that the directory with its respective files was successfully deleted to prevent the other tests from failing because they use the same directory and files.