### PR TITLE
MULE-16806: Fix mule-file-connector tests in Windows

### DIFF
--- a/src/test/java/org/mule/extension/file/integration/FileListTestCase.java
+++ b/src/test/java/org/mule/extension/file/integration/FileListTestCase.java
@@ -6,12 +6,14 @@
  */
 package org.mule.extension.file.integration;
 
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
 import static org.mule.extension.file.AllureConstants.FileFeature.FILE_EXTENSION;
 import static org.mule.extension.file.common.api.exceptions.FileError.ACCESS_DENIED;
 import static org.mule.extension.file.common.api.exceptions.FileError.ILLEGAL_PATH;
@@ -77,6 +79,7 @@ public class FileListTestCase extends FileConnectorTestCase {
 
   @Test
   public void listWithDirectoryWithoutReadPermission() throws Exception {
+    assumeFalse(IS_OS_WINDOWS);
     temporaryFolder.newFolder("forbiddenDirectory").setReadable(false);
     List<Message> messages = doListWithSizeCheck(".", true);
     assertRecursiveTreeNode(messages);
@@ -84,6 +87,7 @@ public class FileListTestCase extends FileConnectorTestCase {
 
   @Test
   public void listWithFileWithoutReadPermission() throws Exception {
+    assumeFalse(IS_OS_WINDOWS);
     temporaryFolder.newFile("forbiddenFile").setReadable(false);
     List<Message> messages = doList(".", false);
 
@@ -93,6 +97,7 @@ public class FileListTestCase extends FileConnectorTestCase {
 
   @Test
   public void listDirectoryWithoutReadPermission() throws Exception {
+    assumeFalse(IS_OS_WINDOWS);
     expectedError.expectError(NAMESPACE, ACCESS_DENIED, FileAccessDeniedException.class,
                               "access was denied by the operating system");
 


### PR DESCRIPTION
Correction of tests that change permissions to directories and files.
These tests will not run in the Windows environment.

This problem has already happened, here are the PRs
- mulesoft/mule-ee-distributions#389 (comment)
- https://github.com/mulesoft/mule-file-connector/pull/91#discussion_r226387304
